### PR TITLE
Fix rmd160 issue without using crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,8 +114,7 @@
     "@types/node": {
       "version": "10.12.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
-      "dev": true
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
     },
     "ansi-regex": {
       "version": "2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bip32",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bip32",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A BIP32 compatible library",
   "keywords": [
     "bip32",

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -2,23 +2,20 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const createHash = require('create-hash');
 const createHmac = require('create-hmac');
-let ripemd160;
-try {
-    ripemd160 = require('crypto')
-        .getHashes()
-        .includes('rmd160')
-        ? 'rmd160'
-        : 'ripemd160';
-}
-catch (err) {
-    ripemd160 = 'rmd160';
-}
 function hash160(buffer) {
-    return createHash(ripemd160)
-        .update(createHash('sha256')
+    const sha256Hash = createHash('sha256')
         .update(buffer)
-        .digest())
         .digest();
+    try {
+        return createHash('rmd160')
+            .update(sha256Hash)
+            .digest();
+    }
+    catch (err) {
+        return createHash('ripemd160')
+            .update(sha256Hash)
+            .digest();
+    }
 }
 exports.hash160 = hash160;
 function hmacSHA512(key, data) {

--- a/ts-src/crypto.ts
+++ b/ts-src/crypto.ts
@@ -1,25 +1,19 @@
 const createHash = require('create-hash');
 const createHmac = require('create-hmac');
 
-let ripemd160: string;
-try {
-  ripemd160 = require('crypto')
-    .getHashes()
-    .includes('rmd160')
-    ? 'rmd160'
-    : 'ripemd160';
-} catch (err) {
-  ripemd160 = 'rmd160';
-}
-
 export function hash160(buffer: Buffer): Buffer {
-  return createHash(ripemd160)
-    .update(
-      createHash('sha256')
-        .update(buffer)
-        .digest(),
-    )
+  const sha256Hash: Buffer = createHash('sha256')
+    .update(buffer)
     .digest();
+  try {
+    return createHash('rmd160')
+      .update(sha256Hash)
+      .digest();
+  } catch (err) {
+    return createHash('ripemd160')
+      .update(sha256Hash)
+      .digest();
+  }
 }
 
 export function hmacSHA512(key: Buffer, data: Buffer): Buffer {


### PR DESCRIPTION
Should fix #18 

@ignition42

Please check this patch to see if it helps you out.

You can install using this:

```
npm install https://github.com/bitcoinjs/bip32.git#patchRmd160-2
```

package.json will look like this:

```
    ...
    "bip32": "git+https://github.com/bitcoinjs/bip32.git#patchRmd160-2",
    ...
```