### PR TITLE
Fix BIP32Factory default export

### DIFF
--- a/src/bip32.js
+++ b/src/bip32.js
@@ -5,7 +5,7 @@ const testecc_1 = require("./testecc");
 const bs58check = require('bs58check');
 const typeforce = require('typeforce');
 const wif = require('wif');
-function default_1(ecc) {
+function BIP32Factory(ecc) {
     testecc_1.testEcc(ecc);
     const UINT256_TYPE = typeforce.BufferN(32);
     const NETWORK_TYPE = typeforce.compile({
@@ -312,4 +312,4 @@ function default_1(ecc) {
         fromPrivateKey,
     };
 }
-exports.default = default_1;
+exports.BIP32Factory = BIP32Factory;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var bip32_1 = require("./bip32");
-exports.default = bip32_1.default;
+exports.default = bip32_1.BIP32Factory;

--- a/src/index.js
+++ b/src/index.js
@@ -2,3 +2,4 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 var bip32_1 = require("./bip32");
 exports.default = bip32_1.BIP32Factory;
+exports.BIP32Factory = bip32_1.BIP32Factory;

--- a/ts-src/bip32.ts
+++ b/ts-src/bip32.ts
@@ -76,7 +76,7 @@ export interface TinySecp256k1Interface {
   verifySchnorr?(h: Uint8Array, Q: Uint8Array, signature: Uint8Array): boolean;
 }
 
-export default function(ecc: TinySecp256k1Interface): BIP32API {
+export function BIP32Factory(ecc: TinySecp256k1Interface): BIP32API {
   testEcc(ecc);
   const UINT256_TYPE = typeforce.BufferN(32);
   const NETWORK_TYPE = typeforce.compile({

--- a/ts-src/index.ts
+++ b/ts-src/index.ts
@@ -1,5 +1,6 @@
 export {
   BIP32Factory as default,
+  BIP32Factory,
   BIP32Interface,
   BIP32API,
   TinySecp256k1Interface,

--- a/ts-src/index.ts
+++ b/ts-src/index.ts
@@ -1,5 +1,5 @@
 export {
-  default,
+  BIP32Factory as default,
   BIP32Interface,
   BIP32API,
   TinySecp256k1Interface,

--- a/types/bip32.d.ts
+++ b/types/bip32.d.ts
@@ -50,5 +50,5 @@ export interface TinySecp256k1Interface {
     verify(h: Uint8Array, Q: Uint8Array, signature: Uint8Array, strict?: boolean): boolean;
     verifySchnorr?(h: Uint8Array, Q: Uint8Array, signature: Uint8Array): boolean;
 }
-export default function (ecc: TinySecp256k1Interface): BIP32API;
+export declare function BIP32Factory(ecc: TinySecp256k1Interface): BIP32API;
 export {};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,1 +1,1 @@
-export { default, BIP32Interface, BIP32API, TinySecp256k1Interface, } from './bip32';
+export { BIP32Factory as default, BIP32Interface, BIP32API, TinySecp256k1Interface, } from './bip32';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,1 +1,1 @@
-export { BIP32Factory as default, BIP32Interface, BIP32API, TinySecp256k1Interface, } from './bip32';
+export { BIP32Factory as default, BIP32Factory, BIP32Interface, BIP32API, TinySecp256k1Interface, } from './bip32';


### PR DESCRIPTION
This PR fixes an issue reported in #53 

Default export gets malformed when reexported as a default and compiled to commonjs. This exports BIP32Factory as a named export and reexports it as a default only from root index file.