### PR TITLE
refactor: make compatible with tiny-secp256k1@1.*

### DIFF
--- a/src/testecc.js
+++ b/src/testecc.js
@@ -14,15 +14,19 @@ function testEcc(ecc) {
     // order + 1
     assert(!ecc.isPrivate(h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142')));
     assert(Buffer.from(ecc.pointFromScalar(h('b1121e4088a66a28f5b6b0f5844943ecd9f610196d7bb83b25214b60452c09af'))).equals(h('02b07ba9dca9523b7ef4bd97703d43d20399eb698e194704791a25ce77a400df99')));
-    assert(ecc.xOnlyPointAddTweak(h('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'), h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140')) === null);
-    let xOnlyRes = ecc.xOnlyPointAddTweak(h('1617d38ed8d8657da4d4761e8057bc396ea9e4b9d29776d4be096016dbd2509b'), h('a8397a935f0dfceba6ba9618f6451ef4d80637abf4e6af2669fbc9de6a8fd2ac'));
-    assert(Buffer.from(xOnlyRes.xOnlyPubkey).equals(h('e478f99dab91052ab39a33ea35fd5e6e4933f4d28023cd597c9a1f6760346adf')) && xOnlyRes.parity === 1);
-    xOnlyRes = ecc.xOnlyPointAddTweak(h('2c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991'), h('823c3cd2142744b075a87eade7e1b8678ba308d566226a0056ca2b7a76f86b47'));
+    if (ecc.xOnlyPointAddTweak) {
+        assert(ecc.xOnlyPointAddTweak(h('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'), h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140')) === null);
+        let xOnlyRes = ecc.xOnlyPointAddTweak(h('1617d38ed8d8657da4d4761e8057bc396ea9e4b9d29776d4be096016dbd2509b'), h('a8397a935f0dfceba6ba9618f6451ef4d80637abf4e6af2669fbc9de6a8fd2ac'));
+        assert(Buffer.from(xOnlyRes.xOnlyPubkey).equals(h('e478f99dab91052ab39a33ea35fd5e6e4933f4d28023cd597c9a1f6760346adf')) && xOnlyRes.parity === 1);
+        xOnlyRes = ecc.xOnlyPointAddTweak(h('2c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991'), h('823c3cd2142744b075a87eade7e1b8678ba308d566226a0056ca2b7a76f86b47'));
+    }
     assert(Buffer.from(ecc.pointAddScalar(h('0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'), h('0000000000000000000000000000000000000000000000000000000000000003'))).equals(h('02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5')));
     assert(Buffer.from(ecc.privateAdd(h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e'), h('0000000000000000000000000000000000000000000000000000000000000002'))).equals(h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140')));
-    assert(Buffer.from(ecc.privateNegate(h('0000000000000000000000000000000000000000000000000000000000000001'))).equals(h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140')));
-    assert(Buffer.from(ecc.privateNegate(h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e'))).equals(h('0000000000000000000000000000000000000000000000000000000000000003')));
-    assert(Buffer.from(ecc.privateNegate(h('b1121e4088a66a28f5b6b0f5844943ecd9f610196d7bb83b25214b60452c09af'))).equals(h('4eede1bf775995d70a494f0a7bb6bc11e0b8cccd41cce8009ab1132c8b0a3792')));
+    if (ecc.privateNegate) {
+        assert(Buffer.from(ecc.privateNegate(h('0000000000000000000000000000000000000000000000000000000000000001'))).equals(h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140')));
+        assert(Buffer.from(ecc.privateNegate(h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e'))).equals(h('0000000000000000000000000000000000000000000000000000000000000003')));
+        assert(Buffer.from(ecc.privateNegate(h('b1121e4088a66a28f5b6b0f5844943ecd9f610196d7bb83b25214b60452c09af'))).equals(h('4eede1bf775995d70a494f0a7bb6bc11e0b8cccd41cce8009ab1132c8b0a3792')));
+    }
     assert(Buffer.from(ecc.sign(h('5e9f0a0d593efdcf78ac923bc3313e4e7d408d574354ee2b3288c0da9fbba6ed'), h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'))).equals(h('54c4a33c6423d689378f160a7ff8b61330444abb58fb470f96ea16d99d4a2fed07082304410efa6b2943111b6a4e0aaa7b7db55a07e9861d1fb3cb1f421044a5')));
     assert(ecc.verify(h('5e9f0a0d593efdcf78ac923bc3313e4e7d408d574354ee2b3288c0da9fbba6ed'), h('0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'), h('54c4a33c6423d689378f160a7ff8b61330444abb58fb470f96ea16d99d4a2fed07082304410efa6b2943111b6a4e0aaa7b7db55a07e9861d1fb3cb1f421044a5')));
     if (ecc.signSchnorr) {

--- a/test/index.js
+++ b/test/index.js
@@ -271,6 +271,19 @@ tape('ecdsa - no schnorr', (t) => {
   t.throws(() => signer.verifySchnorr(hash), /verifySchnorr not supported by ecc library/)
 })
 
+tape('ecc without tweak support', (t) => {
+  let seed = Buffer.alloc(32, 1)
+  const tweak = Buffer.alloc(32, 3)
+
+  const bip32NoTweak = BIP32Creator({ ...ecc, xOnlyPointAddTweak: null, privateNegate: null })
+  const node = bip32NoTweak.fromSeed(seed)
+  const nodeWithoutPrivKey = bip32NoTweak.fromPublicKey(node.publicKey, node.chainCode)
+
+  t.plan(2)
+  t.throws(() => node.tweak(tweak), /privateNegate not supported by ecc library/)
+  t.throws(() => nodeWithoutPrivKey.tweak(tweak), /xOnlyPointAddTweak not supported by ecc library/)
+})
+
 tape('tweak', (t) => {
   const seed = Buffer.alloc(32, 1)
   const hash = Buffer.alloc(32, 2)

--- a/ts-src/bip32.ts
+++ b/ts-src/bip32.ts
@@ -415,12 +415,10 @@ export function BIP32Factory(ecc: TinySecp256k1Interface): BIP32API {
         this.publicKey[0] === 3 ||
         (this.publicKey[0] === 4 && (this.publicKey[64] & 1) === 1);
       const privateKey = (() => {
-        if (!hasOddY) 
-          return this.privateKey
-        else if (!ecc.privateNegate) 
+        if (!hasOddY) return this.privateKey;
+        else if (!ecc.privateNegate)
           throw new Error('privateNegate not supported by ecc library');
-        else 
-          return ecc.privateNegate(this.privateKey!);
+        else return ecc.privateNegate(this.privateKey!);
       })();
       const tweakedPrivateKey = ecc.privateAdd(privateKey!, t);
       if (!tweakedPrivateKey) throw new Error('Invalid tweaked private key!');

--- a/ts-src/testecc.ts
+++ b/ts-src/testecc.ts
@@ -51,27 +51,29 @@ export function testEcc(ecc: TinySecp256k1Interface): void {
       h('02b07ba9dca9523b7ef4bd97703d43d20399eb698e194704791a25ce77a400df99'),
     ),
   );
-  assert(
-    ecc.xOnlyPointAddTweak(
-      h('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
-      h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
-    ) === null,
-  );
+  if (ecc.xOnlyPointAddTweak) {
+    assert(
+      ecc.xOnlyPointAddTweak(
+        h('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
+        h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
+      ) === null,
+    );
 
-  let xOnlyRes = ecc.xOnlyPointAddTweak(
-    h('1617d38ed8d8657da4d4761e8057bc396ea9e4b9d29776d4be096016dbd2509b'),
-    h('a8397a935f0dfceba6ba9618f6451ef4d80637abf4e6af2669fbc9de6a8fd2ac'),
-  );
-  assert(
-    Buffer.from(xOnlyRes!.xOnlyPubkey).equals(
-      h('e478f99dab91052ab39a33ea35fd5e6e4933f4d28023cd597c9a1f6760346adf'),
-    ) && xOnlyRes!.parity === 1,
-  );
+    let xOnlyRes = ecc.xOnlyPointAddTweak(
+      h('1617d38ed8d8657da4d4761e8057bc396ea9e4b9d29776d4be096016dbd2509b'),
+      h('a8397a935f0dfceba6ba9618f6451ef4d80637abf4e6af2669fbc9de6a8fd2ac'),
+    );
+    assert(
+      Buffer.from(xOnlyRes!.xOnlyPubkey).equals(
+        h('e478f99dab91052ab39a33ea35fd5e6e4933f4d28023cd597c9a1f6760346adf'),
+      ) && xOnlyRes!.parity === 1,
+    );
 
-  xOnlyRes = ecc.xOnlyPointAddTweak(
-    h('2c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991'),
-    h('823c3cd2142744b075a87eade7e1b8678ba308d566226a0056ca2b7a76f86b47'),
-  );
+    xOnlyRes = ecc.xOnlyPointAddTweak(
+      h('2c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991'),
+      h('823c3cd2142744b075a87eade7e1b8678ba308d566226a0056ca2b7a76f86b47'),
+    );
+  }
   assert(
     Buffer.from(
       ecc.pointAddScalar(
@@ -92,33 +94,35 @@ export function testEcc(ecc: TinySecp256k1Interface): void {
       h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
     ),
   );
-  assert(
-    Buffer.from(
-      ecc.privateNegate(
-        h('0000000000000000000000000000000000000000000000000000000000000001'),
+  if (ecc.privateNegate) {
+    assert(
+      Buffer.from(
+        ecc.privateNegate(
+          h('0000000000000000000000000000000000000000000000000000000000000001'),
+        ),
+      ).equals(
+        h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
       ),
-    ).equals(
-      h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
-    ),
-  );
-  assert(
-    Buffer.from(
-      ecc.privateNegate(
-        h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e'),
+    );
+    assert(
+      Buffer.from(
+        ecc.privateNegate(
+          h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e'),
+        ),
+      ).equals(
+        h('0000000000000000000000000000000000000000000000000000000000000003'),
       ),
-    ).equals(
-      h('0000000000000000000000000000000000000000000000000000000000000003'),
-    ),
-  );
-  assert(
-    Buffer.from(
-      ecc.privateNegate(
-        h('b1121e4088a66a28f5b6b0f5844943ecd9f610196d7bb83b25214b60452c09af'),
+    );
+    assert(
+      Buffer.from(
+        ecc.privateNegate(
+          h('b1121e4088a66a28f5b6b0f5844943ecd9f610196d7bb83b25214b60452c09af'),
+        ),
+      ).equals(
+        h('4eede1bf775995d70a494f0a7bb6bc11e0b8cccd41cce8009ab1132c8b0a3792'),
       ),
-    ).equals(
-      h('4eede1bf775995d70a494f0a7bb6bc11e0b8cccd41cce8009ab1132c8b0a3792'),
-    ),
-  );
+    );
+  }
   assert(
     Buffer.from(
       ecc.sign(

--- a/types/bip32.d.ts
+++ b/types/bip32.d.ts
@@ -56,8 +56,8 @@ export interface TinySecp256k1Interface {
     signSchnorr?(h: Uint8Array, d: Uint8Array, e?: Uint8Array): Uint8Array;
     verify(h: Uint8Array, Q: Uint8Array, signature: Uint8Array, strict?: boolean): boolean;
     verifySchnorr?(h: Uint8Array, Q: Uint8Array, signature: Uint8Array): boolean;
-    xOnlyPointAddTweak(p: Uint8Array, tweak: Uint8Array): XOnlyPointAddTweakResult | null;
-    privateNegate(d: Uint8Array): Uint8Array;
+    xOnlyPointAddTweak?(p: Uint8Array, tweak: Uint8Array): XOnlyPointAddTweakResult | null;
+    privateNegate?(d: Uint8Array): Uint8Array;
 }
 export declare function BIP32Factory(ecc: TinySecp256k1Interface): BIP32API;
 export {};


### PR DESCRIPTION
#55 shows the inconvenience to use bip32 because of the dependency on tiny-secp256k1@2.0.0+ including WASM, which requires some tricky config for app or web based engine.
As mentioned, if downgrade tiny-secp256k1 to version 1.1.6 not including WASM, it can be perfectly compatible with browser/app.
Though latest bip32 at that time was compatible with tiny-secp256k1@1.1.6, current version adds "testecc.js" which requires "xOnlyPointAddTweak" and "privateNegate" methods for tiny-secp256k1. As you know, tiny-secp256k1 v1 does not have those methods(like schnorr), so just wrap it up with if statement.
Tweak methods of BIP32 has a strong utility, but not necessarily used for most of dev who implements this library. It can be optional, to make lib more usable for devs.