### PR TITLE
Fix: Replace JSON import assertion with fs/promises API for better Node.js compatibility

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,14 @@
 import BIP32Creator from '../src/esm/index.js'
 import tape from 'tape'
-import fixtures from './fixtures/index.json' assert { type: "json" }
-const { valid, invalid } = fixtures 
+import { readFile } from 'fs/promises'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const fixtures = JSON.parse(
+  await readFile(join(__dirname, './fixtures/index.json'), 'utf8')
+)
+const { valid, invalid } = fixtures
 import * as ecc from "tiny-secp256k1";
 import * as tools from "uint8array-tools";
 const BIP32 = BIP32Creator(ecc)


### PR DESCRIPTION
This PR replaces the JSON import assertion in test files with the fs/promises API for better Node.js compatibility. This change makes the tests more compatible with different Node.js versions and environments.

Changes made:
- Updated test/index.js to use fs/promises readFile instead of JSON import assertion
- Added proper file path resolution using path and url modules