### PR TITLE
Fix: bump valibot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@noble/hashes": "^1.2.0",
         "@scure/base": "^1.1.1",
         "uint8array-tools": "^0.0.8",
-        "valibot": "^0.37.0",
+        "valibot": "^1.2.0",
         "wif": "^5.0.0"
       },
       "devDependencies": {
@@ -2569,9 +2569,10 @@
       "dev": true
     },
     "node_modules/valibot": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.37.0.tgz",
-      "integrity": "sha512-FQz52I8RXgFgOHym3XHYSREbNtkgSjF9prvMFH1nBsRyfL6SfCzoT1GuSDTlbsuPubM7/6Kbw0ZMQb8A+V+VsQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bip32",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bip32",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@noble/hashes": "^1.2.0",
     "@scure/base": "^1.1.1",
     "uint8array-tools": "^0.0.8",
-    "valibot": "^0.37.0",
+    "valibot": "^1.2.0",
     "wif": "^5.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bip32",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "type": "module",
   "description": "A BIP32 compatible library",
   "keywords": [

--- a/src/cjs/types.d.ts
+++ b/src/cjs/types.d.ts
@@ -1,14 +1,14 @@
 import * as v from 'valibot';
-export declare const Uint32Schema: v.SchemaWithPipe<[v.NumberSchema<undefined>, v.IntegerAction<number, undefined>, v.MinValueAction<number, 0, undefined>, v.MaxValueAction<number, 4294967295, undefined>]>;
-export declare const Uint31Schema: v.SchemaWithPipe<[v.NumberSchema<undefined>, v.IntegerAction<number, undefined>, v.MinValueAction<number, 0, undefined>, v.MaxValueAction<number, 2147483647, undefined>]>;
-export declare const Buffer256Bit: v.SchemaWithPipe<[v.InstanceSchema<Uint8ArrayConstructor, undefined>, v.LengthAction<Uint8Array, 32, undefined>]>;
-export declare const Buffer33Bytes: v.SchemaWithPipe<[v.InstanceSchema<Uint8ArrayConstructor, undefined>, v.LengthAction<Uint8Array, 33, undefined>]>;
+export declare const Uint32Schema: v.SchemaWithPipe<readonly [v.NumberSchema<undefined>, v.IntegerAction<number, undefined>, v.MinValueAction<number, 0, undefined>, v.MaxValueAction<number, 4294967295, undefined>]>;
+export declare const Uint31Schema: v.SchemaWithPipe<readonly [v.NumberSchema<undefined>, v.IntegerAction<number, undefined>, v.MinValueAction<number, 0, undefined>, v.MaxValueAction<number, 2147483647, undefined>]>;
+export declare const Buffer256Bit: v.SchemaWithPipe<readonly [v.InstanceSchema<Uint8ArrayConstructor, undefined>, v.LengthAction<Uint8Array, 32, undefined>]>;
+export declare const Buffer33Bytes: v.SchemaWithPipe<readonly [v.InstanceSchema<Uint8ArrayConstructor, undefined>, v.LengthAction<Uint8Array, 33, undefined>]>;
 export declare const NetworkSchema: v.ObjectSchema<{
-    readonly wif: v.SchemaWithPipe<[v.NumberSchema<undefined>, v.IntegerAction<number, undefined>, v.MinValueAction<number, 0, undefined>, v.MaxValueAction<number, 255, undefined>]>;
+    readonly wif: v.SchemaWithPipe<readonly [v.NumberSchema<undefined>, v.IntegerAction<number, undefined>, v.MinValueAction<number, 0, undefined>, v.MaxValueAction<number, 255, undefined>]>;
     readonly bip32: v.ObjectSchema<{
-        readonly public: v.SchemaWithPipe<[v.NumberSchema<undefined>, v.IntegerAction<number, undefined>, v.MinValueAction<number, 0, undefined>, v.MaxValueAction<number, 4294967295, undefined>]>;
-        readonly private: v.SchemaWithPipe<[v.NumberSchema<undefined>, v.IntegerAction<number, undefined>, v.MinValueAction<number, 0, undefined>, v.MaxValueAction<number, 4294967295, undefined>]>;
+        readonly public: v.SchemaWithPipe<readonly [v.NumberSchema<undefined>, v.IntegerAction<number, undefined>, v.MinValueAction<number, 0, undefined>, v.MaxValueAction<number, 4294967295, undefined>]>;
+        readonly private: v.SchemaWithPipe<readonly [v.NumberSchema<undefined>, v.IntegerAction<number, undefined>, v.MinValueAction<number, 0, undefined>, v.MaxValueAction<number, 4294967295, undefined>]>;
     }, undefined>;
 }, undefined>;
-export declare const Bip32PathSchema: v.SchemaWithPipe<[v.StringSchema<undefined>, v.RegexAction<string, undefined>]>;
+export declare const Bip32PathSchema: v.SchemaWithPipe<readonly [v.StringSchema<undefined>, v.RegexAction<string, undefined>]>;
 export type Network = v.InferOutput<typeof NetworkSchema>;


### PR DESCRIPTION
Bumps valibot to ^1.2.0 to fix a high severity ReDoS vulnerability in EMOJI_REGEX.
Also updates npm version to 5.0.1.

This is the same issue addressed in https://github.com/bitcoinjs/ecpair/pull/34 and https://github.com/bitcoinjs/bitcoinjs-lib/pull/2308.

I can also handle the release @junderw, if that's ok.